### PR TITLE
Added default arguments to make it compile

### DIFF
--- a/insert_structs.go
+++ b/insert_structs.go
@@ -38,9 +38,9 @@ func InsertStructs(ctx context.Context, client *bigquery.Client, dataset, table 
 	MakeOptional(schema)
 
 	ds := client.Dataset(dataset)
-	ds.Create(ctx) // Ignore error, which is returned if the dataset already exists.
+	ds.Create(ctx, nil) // Ignore error, which is returned if the dataset already exists.
 	t := ds.Table(table)
-	t.Create(ctx, bigquery.UseStandardSQL()) // Ignore error, which is returned if the table already exists.
+	t.Create(ctx, nil) // Ignore error, which is returned if the table already exists.
 	md, err := t.Metadata(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
The "UseStandardSQL" field in the struct was deprecated, and now it's just the opposite of "UseLegacySQL". It's now the default setting (see https://github.com/GoogleCloudPlatform/google-cloud-go/commit/56e8f25c06ab5d4bcd455b8eb9808da9a180d418#diff-231d71396207928b46ee60a3ac52f1cd), so we shouldn't have to do anything but pass in nil.